### PR TITLE
chg: Logger initialisation functions moved to Sysdiagnose class

### DIFF
--- a/src/sysdiagnose/__init__.py
+++ b/src/sysdiagnose/__init__.py
@@ -7,7 +7,8 @@ import os
 import re
 import tarfile
 import fcntl
-from sysdiagnose.utils.base import BaseParserInterface, BaseAnalyserInterface, SysdiagnoseConfig, logger
+from sysdiagnose.utils.base import BaseParserInterface, BaseAnalyserInterface, SysdiagnoseConfig
+from sysdiagnose.utils.logger import set_json_logging, logger
 
 
 class Sysdiagnose:
@@ -180,6 +181,12 @@ class Sysdiagnose:
 
         print(f"Sysdiagnose file has been processed: {sysdiagnose_file}")
         return case
+
+    def init_case_logging(self, mode: str, case_id: str) -> None:
+        ''' Initialises the file handler '''
+        folder = self.config.get_case_log_data_folder(case_id=case_id)
+        file_path = os.path.join(folder, f'log-{mode}.jsonl')
+        set_json_logging(filename=file_path)
 
     def parse(self, parser: str, case_id: str):
         # Load parser module

--- a/tests/test_sysdiagnose.py
+++ b/tests/test_sysdiagnose.py
@@ -4,6 +4,7 @@ import unittest
 import tempfile
 import shutil
 import glob
+import os
 
 
 class TestSysdiagnose(SysdiagnoseTestCase):
@@ -52,6 +53,15 @@ class TestSysdiagnose(SysdiagnoseTestCase):
             # Ensure the temporary directory is cleaned up after the test
             shutil.rmtree(temp_dir)
 
+    def test_init_case_logging(self):
+        try:
+            temp_dir = tempfile.mkdtemp()
+            sd = Sysdiagnose(cases_path=temp_dir)
+            sd.init_case_logging(mode='parse', case_id='1')
+            self.assertTrue(os.path.exists(os.path.join(sd.config.get_case_log_data_folder('1'), 'log-parse.jsonl')))
+        finally:
+            # Ensure the temporary directory is cleaned up after the test
+            shutil.rmtree(temp_dir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sysdiagnose.py
+++ b/tests/test_sysdiagnose.py
@@ -63,5 +63,6 @@ class TestSysdiagnose(SysdiagnoseTestCase):
             # Ensure the temporary directory is cleaned up after the test
             shutil.rmtree(temp_dir)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Encapsulate the logger initialisation so that it is easier in case Sysdiagnose is used as a module instead.