### PR TITLE
Added ioservice parser + unit testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -316,6 +316,14 @@
             "module": "sysdiagnose.__main__",
             "args": "-c public parse swcutil",
             "cwd": "${workspaceFolder}/"
+        },
+        {
+            "name": "Python Debugger: parse ioservice",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "sysdiagnose.__main__",
+            "args": "-c public -l DEBUG parse ioservice",
+            "cwd": "${workspaceFolder}/"
         }
     ]
 }

--- a/src/sysdiagnose/parsers/ioservice.py
+++ b/src/sysdiagnose/parsers/ioservice.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python3
+
+import os
+import string
+from tokenize import String
+from sysdiagnose.utils.base import BaseParserInterface, SysdiagnoseConfig, logger, Event
+from datetime import datetime
+
+
+class DemoParser(BaseParserInterface):
+    description = "Demo parsers"
+    format = "json"  # by default json, use jsonl for event-based data
+    rollback_addr = None
+    line = None
+    open_file = None
+
+    def __init__(self, config: SysdiagnoseConfig, case_id: str):
+        super().__init__(__file__, config, case_id)
+
+    def get_log_files(self) -> list:
+        log_file = "ioreg/IOServiceTestData.txt"
+        return [os.path.join(self.case_data_subfolder, log_file)]
+
+    def execute(self) -> list | dict:
+        '''
+        this is the function that will be called
+        '''
+        result = []
+        log_files = self.get_log_files()
+        for log_file in log_files:
+            entry = {}
+            try:
+                timestamp = datetime.strptime('1980-01-01 12:34:56.001 +00:00', '%Y-%m-%d %H:%M:%S.%f %z')  # moment of interest
+                event = Event(
+                    datetime=timestamp,
+                    message=f"Demo event from {log_file}",  # String with an informative message of the event
+                    module=self.module_name,
+                    timestamp_desc='Demo timestamp',        # String explaining what type of timestamp it is for example file created
+                )
+
+                self.parse_file(log_file)
+
+                result.append(event.to_dict())
+                logger.info(f"Processing file {log_file}, new entry added", extra={'log_file': log_file})
+                logger.debug(f"Entry details {str(entry)}", extra={'entry': str(entry)})
+                if not entry:
+                    logger.warning("Empty entry.")
+                    
+            except Exception:
+                logger.exception("Got an exception !")
+                
+        return result
+    
+    def parse_file(self, file: string):
+        """           IOService file notes
+
+            # Regex for +-o starting at start of file -> 1213 results
+            (\s|\|)*\+-o
+
+            # Regex for ALL +-o - 1213 results
+            \+-o
+
+            So we know that the data doesn't contain the node identifier ('+-o')
+
+        """
+        print('===============================')
+        with open(file, 'r') as f:
+            self.open_file = f
+            self.recursive_fun()
+            self.open_file = None
+        print('===============================')
+
+    def get_line(self):
+        self.rollback_addr = self.open_file.tell()
+        self.line = self.open_file.readline().replace('\n', '')
+
+    def recursive_call(self):
+        self.open_file.seek(self.rollback_addr)
+        self.recursive_fun()
+
+    def check_start_node(self):
+        if '+-o' not in self.line:
+            logger.error('This is not normal. Recursive function called on random line.')
+            exit(1)
+
+    def not_empty_node_check(self):
+        if not self.rollback_addr:
+            logger.error("+-o in two consecutive lines, not supposed to be possible")
+            exit(1)
+
+    def iterate_children(self, depth):
+        while self.line and (self.line[depth] == '|' or self.line[depth: depth+3] == '+-o'):
+            if self.line[depth: depth+3] == '+-o':
+                self.recursive_call()
+
+            else:
+                self.get_line()
+
+    def fetch_node_data(self):
+        while '+-o' not in self.line:
+            if not self.line:
+                return False # end of file
+            
+            node_data = [] # array of lines, to be transformed in json
+            node_data.append(self.line)
+            self.get_line()
+
+        return True
+    
+    def recursive_fun(self):
+        is_leaf = False
+        self.get_line()
+
+        # check if we're at the start of a node
+        self.check_start_node()
+
+        node_name = self.line.split("+-o")[1].strip()
+        print("Node : ", node_name)
+        depth = self.line.index('o') # to identify the other nodes that have the same parent
+        self.get_line()
+
+        # check if its a leaf
+        if self.line[depth] != '|':
+            is_leaf = True
+
+        # Fetch the data of the node
+        if not self.fetch_node_data():
+            return  # EOF
+
+        # stop if we're a leaf
+        if is_leaf:
+            self.open_file.seek(self.rollback_addr)
+            return
+            
+        # sanity check
+        self.not_empty_node_check()
+
+        # going back one line to retrieve the node title line
+        self.recursive_call()
+        self.get_line()
+
+        # Iterates over each child to call the current function
+        self.iterate_children(depth)
+        
+        
+
+

--- a/src/sysdiagnose/parsers/ioservice.py
+++ b/src/sysdiagnose/parsers/ioservice.py
@@ -1,13 +1,9 @@
 #! /usr/bin/env python3
 
-import array
-from ctypes import Array
 from io import BufferedReader
 import os
-from tokenize import String
-from sysdiagnose.utils.base import BaseParserInterface, SysdiagnoseConfig, logger
-from datetime import datetime
 import re
+from sysdiagnose.utils.base import BaseParserInterface, SysdiagnoseConfig, logger
 
 
 class IOServiceParser(BaseParserInterface):
@@ -16,7 +12,6 @@ class IOServiceParser(BaseParserInterface):
     rollback_addr = None
     line = None
     open_file = None
-    
 
     def __init__(self, config: SysdiagnoseConfig, case_id: str):
         super().__init__(__file__, config, case_id)
@@ -33,12 +28,12 @@ class IOServiceParser(BaseParserInterface):
             try:
                 logger.info(f"Processing file {log_file}, new entry added", extra={'log_file': log_file})
                 self.parse_file(log_file, data_tree)
-                    
+
             except Exception:
                 logger.exception("IOService parsing crashed")
-                
+
         return data_tree
-    
+
     def parse_file(self, file: str, data_tree: dict):
         """           IOService file notes
 
@@ -50,7 +45,7 @@ class IOServiceParser(BaseParserInterface):
 
             So we know that the data doesn't contain the node identifier ('+-o')
 
-        """
+        """  # noqa: W605
         with open(file, 'rb') as f:
             self.open_file = f
             self.recursive_fun(data_tree)
@@ -73,7 +68,7 @@ class IOServiceParser(BaseParserInterface):
         while True:
             byte = open_file.read(1)
 
-            if not byte: # EOF
+            if not byte:  # EOF
                 return buffer
 
             if byte == b'\n':
@@ -84,8 +79,6 @@ class IOServiceParser(BaseParserInterface):
                     buffer += chr(byte[0])
                 else:
                     buffer += replacement_char[0]
-                #buffer.append(byte[0] if ord(byte[0]) < 128 else replacement_byte[0])
-
 
     def recursive_call(self, data_tree: dict):
         self.open_file.seek(self.rollback_addr)
@@ -106,31 +99,31 @@ class IOServiceParser(BaseParserInterface):
             logger.warning('Key is already in dictionary, data may be lost')
 
     def fetch_node_data(self, data_tree: dict) -> bool:
-        node_data = [] # array of lines, to be transformed in json
+        node_data = []  # array of lines, to be transformed in json
         res = True
 
         while '+-o' not in self.line:
             if not self.line:   # end of file
                 res = False
                 break
-            
+
             node_data.append(self.line)
             self.get_line()
 
         data_tree['Data'] = self.node_data_to_json(node_data)
         return res
-    
+
     def handle_anomalies(self, dictio: dict, data: str, key: str) -> bool:
         """
             some values overflow on the few next lines
             this condition assumes there is no '=' in the exceeding data
             (which was the case up to what I saw)
 
-            p.s. :  if you wonder why cond4 is necessary, it is only for 
+            p.s. :  if you wonder why cond4 is necessary, it is only for
                     the last leaf, which has no '|' symbols. without cond4,
                     these lines would be seen as anomalies
         """
-        cond1 = not re.search('^\s*\|+', data)
+        cond1 = not re.search(r'^\s*\|+', data)
         cond2 = len(data.strip()) > 0
         cond3 = data.strip() not in ('{', '}')
         cond4 = '=' not in data
@@ -139,7 +132,7 @@ class IOServiceParser(BaseParserInterface):
             dictio[key] += data.strip()
             return True
         return False
-    
+
     def node_data_to_json(self, data_array: list[str]) -> dict:
         res = {}
         key = None
@@ -148,7 +141,7 @@ class IOServiceParser(BaseParserInterface):
             self.handle_anomalies(res, data, key)
 
             # remove spaces and pipes at start
-            clean_line = re.sub('^(\s|\|)*', '', data)
+            clean_line = re.sub(r'^(\s|\|)*', '', data)
 
             if '=' not in clean_line:
                 continue
@@ -163,18 +156,18 @@ class IOServiceParser(BaseParserInterface):
 
             self.check_key_uniqueness(res, key)
             res[key] = value.strip()
-        
+
         return res
-    
+
     def iterate_children(self, depth: int, data_tree_list: list[dict]):
-        while self.line and (self.line[depth] == '|' or self.line[depth: depth+3] == '+-o'):
-            if self.line[depth: depth+3] == '+-o':
+        while self.line and (self.line[depth] == '|' or self.line[depth: depth + 3] == '+-o'):
+            if self.line[depth: depth + 3] == '+-o':
                 data_tree_list.append({})
                 self.recursive_call(data_tree_list[-1])
 
             else:
                 self.get_line()
-    
+
     def recursive_fun(self, data_tree: dict):
         is_leaf = False
         self.get_line()
@@ -185,7 +178,7 @@ class IOServiceParser(BaseParserInterface):
         node_name = self.line.split("+-o")[1].strip()
         data_tree['Name'] = node_name
         data_tree['Children'] = []
-        depth = self.line.index('o') # to identify the other nodes that have the same parent
+        depth = self.line.index('o')  # to identify the other nodes that have the same parent
         self.get_line()
 
         # check if its a leaf
@@ -200,13 +193,9 @@ class IOServiceParser(BaseParserInterface):
         if is_leaf:
             self.open_file.seek(self.rollback_addr)
             return
-            
+
         # sanity check
         self.not_empty_node_check()
 
         # Iterates over each child to call the current function
         self.iterate_children(depth, data_tree['Children'])
-        
-        
-
-

--- a/src/sysdiagnose/parsers/ioservice.py
+++ b/src/sysdiagnose/parsers/ioservice.py
@@ -2,8 +2,8 @@
 
 import array
 from ctypes import Array
+from io import BufferedReader
 import os
-import string
 from tokenize import String
 from sysdiagnose.utils.base import BaseParserInterface, SysdiagnoseConfig, logger
 from datetime import datetime
@@ -22,7 +22,7 @@ class IOServiceParser(BaseParserInterface):
         super().__init__(__file__, config, case_id)
 
     def get_log_files(self) -> list:
-        log_file = "ioreg/IOServiceTestData2.txt"
+        log_file = "ioreg/IOService.txt"
         return [os.path.join(self.case_data_subfolder, log_file)]
 
     def execute(self) -> list | dict:
@@ -51,14 +51,41 @@ class IOServiceParser(BaseParserInterface):
             So we know that the data doesn't contain the node identifier ('+-o')
 
         """
-        with open(file, 'r') as f:
+        with open(file, 'rb') as f:
             self.open_file = f
             self.recursive_fun(data_tree)
             self.open_file = None
 
     def get_line(self):
         self.rollback_addr = self.open_file.tell()
-        self.line = self.open_file.readline().replace('\n', '')
+        self.line = self.safe_readline(self.open_file)
+        self.line = self.line.replace('\n', '')
+
+    def safe_readline(self, open_file: BufferedReader, replacement_char: str = '?'):
+        """
+        Simulates readline() in binary mode, replacing non-ASCII bytes.
+
+        This fixes an anomaly where a non-ascii (non-utf-8-) byte is present in the IOService.txt file
+        (line 10797 in the testdata)
+        """
+        buffer = ""
+
+        while True:
+            byte = open_file.read(1)
+
+            if not byte: # EOF
+                return buffer
+
+            if byte == b'\n':
+                return buffer
+            else:
+                # Check if ASCII (0–127), else replace
+                if byte[0] < 128:
+                    buffer += chr(byte[0])
+                else:
+                    buffer += replacement_char[0]
+                #buffer.append(byte[0] if ord(byte[0]) < 128 else replacement_byte[0])
+
 
     def recursive_call(self, data_tree: dict):
         self.open_file.seek(self.rollback_addr)
@@ -74,20 +101,11 @@ class IOServiceParser(BaseParserInterface):
             logger.error("+-o in two consecutive lines, not supposed to be possible")
             exit(1)
 
-    def iterate_children(self, depth: int, data_tree_list: list[dict]):
-        while self.line and (self.line[depth] == '|' or self.line[depth: depth+3] == '+-o'):
-            if self.line[depth: depth+3] == '+-o':
-                data_tree_list.append({})
-                self.recursive_call(data_tree_list[-1])
-
-            else:
-                self.get_line()
-
-    def check_key_uniqueness(self, dictio, key):
+    def check_key_uniqueness(self, dictio: dict, key: str):
         if dictio.get(key):
             logger.warning('Key is already in dictionary, data may be lost')
 
-    def fetch_node_data(self, data_tree):
+    def fetch_node_data(self, data_tree: dict) -> bool:
         node_data = [] # array of lines, to be transformed in json
         res = True
 
@@ -102,7 +120,7 @@ class IOServiceParser(BaseParserInterface):
         data_tree['Data'] = self.node_data_to_json(node_data)
         return res
     
-    def handle_anomalies(self, dictio, data, key):
+    def handle_anomalies(self, dictio: dict, data: str, key: str) -> bool:
         """
             some values overflow on the few next lines
             this condition assumes there is no '=' in the exceeding data
@@ -147,6 +165,15 @@ class IOServiceParser(BaseParserInterface):
             res[key] = value.strip()
         
         return res
+    
+    def iterate_children(self, depth: int, data_tree_list: list[dict]):
+        while self.line and (self.line[depth] == '|' or self.line[depth: depth+3] == '+-o'):
+            if self.line[depth: depth+3] == '+-o':
+                data_tree_list.append({})
+                self.recursive_call(data_tree_list[-1])
+
+            else:
+                self.get_line()
     
     def recursive_fun(self, data_tree: dict):
         is_leaf = False

--- a/tests/test_parsers_ioservice.py
+++ b/tests/test_parsers_ioservice.py
@@ -1,0 +1,363 @@
+from sysdiagnose.parsers.ioservice import IOServiceParser
+from tests import SysdiagnoseTestCase
+import unittest
+import io
+
+
+class TestParsersIOService(SysdiagnoseTestCase):
+
+    def test_basic_structure(self):
+        for case_id, _ in self.sd.cases().items():
+            p = IOServiceParser(self.sd.config, case_id=case_id)
+        
+        # careful, spaces and structure is important
+        # This simulates an open file object, as if we opened it with open(path, 'rb')
+        start_file = io.BytesIO(b"""+-o Root node
+  | {
+  |   "data 1" = "value 1"
+  |   "data 2" = "value 2"
+  | }
+  | 
+  +-o Node 2
+    | {
+    |   "#address-cells" = <02000000>
+    |   "AAPL,phandle" = <01000000> 
+    | }
+    | 
+    +-o Node 3
+    | | {
+    | |   "data 31" = "value 31"
+    | |   "data 32" = "value 32"
+    | | }
+    | | 
+    | +-o Leaf 1
+    | | {
+    | |   "data l1" = "value l1"
+    | |   "data l2" = "value l2"
+    | | }
+    | |
+    | +-o Leaf 2
+    |   {
+    |     "data l3" = "value l3"
+    |     "data l4" = "value l4"
+    |   }
+    | 
+    +-o Leaf 3
+    | {
+    |   "data l5" = "value L5"
+    |   "data l6" = "value l6"
+    | }
+    |
+    +-o Leaf 4
+        {
+          "data 51" = "value 51"
+          "data 52" = "value 52"
+        }
+        
+""")
+        
+        expected = {
+            "Children": [
+                {
+                "Children": [
+                    {
+                    "Children": [
+                        {
+                        "Children": [],
+                        "Data": {
+                            "data l1": "\"value l1\"",
+                            "data l2": "\"value l2\""
+                        },
+                        "Name": "Leaf 1"
+                        },
+                        {
+                        "Children": [],
+                        "Data": {
+                            "data l3": "\"value l3\"",
+                            "data l4": "\"value l4\""
+                        },
+                        "Name": "Leaf 2"
+                        }
+                    ],
+                    "Data": {
+                        "data 31": "\"value 31\"",
+                        "data 32": "\"value 32\""
+                    },
+                    "Name": "Node 3"
+                    },
+                    {
+                    "Children": [],
+                    "Data": {
+                        "data l5": "\"value L5\"",
+                        "data l6": "\"value l6\""
+                    },
+                    "Name": "Leaf 3"
+                    },
+                    {
+                    "Children": [],
+                    "Data": {
+                        "data 51": "\"value 51\"",
+                        "data 52": "\"value 52\""
+                    },
+                    "Name": "Leaf 4"
+                    }
+                ],
+                "Data": {
+                    "#address-cells": "<02000000>",
+                    "AAPL,phandle": "<01000000>"
+                },
+                "Name": "Node 2"
+                }
+            ],
+            "Data": {
+                "data 1": "\"value 1\"",
+                "data 2": "\"value 2\""
+            },
+            "Name": "Root node"
+        }
+
+        p.open_file = start_file
+        result = {}
+        p.recursive_fun(result)
+
+        self.assertTrue(result == expected)
+
+    def test_value_overflow_anomaly(self):
+        for case_id, _ in self.sd.cases().items():
+            p = IOServiceParser(self.sd.config, case_id=case_id)
+        
+        # careful, spaces and structure is important
+        # This simulates an open file object, as if we opened it with open(path, 'rb')
+        start_file = io.BytesIO(b"""+-o Root node
+  | {
+  |   "data 1" = "value 1"
+  |   "data 2" = "value 2"
+  | }
+  | 
+  +-o Node 2
+    | {
+    |   "#address-cells" = <02000000>
+    |   "AAPL,phandle" = <01000000> 
+    | }
+    | 
+    +-o Node 3
+    | | {
+    | |   "data 31" = "value 31"
+    | |   "data 32" = "value 32"
+    | | }
+    | | 
+    | +-o Leaf 1
+    | | {
+    | |   "data l1" = "value l1"
+    | |   "data l2" = "value l2"
+    | | }
+    | |
+    | +-o Leaf 2
+    |   {
+    |     "data l3" = "value l3"
+    |     "data l4" = "value aaaa
+bbbb
+cccc
+dddd
+"
+    |   }
+    | 
+    +-o Leaf 3
+    | {
+    |   "data l5" = "value L5"
+    |   "data l6" = "value l6"
+    | }
+    |
+    +-o Leaf 4
+        {
+          "data 51" = "value 51"
+          "data 52" = "value 52"
+        }
+        
+""")
+        
+        expected = {
+            "Children": [
+                {
+                "Children": [
+                    {
+                    "Children": [
+                        {
+                        "Children": [],
+                        "Data": {
+                            "data l1": "\"value l1\"",
+                            "data l2": "\"value l2\""
+                        },
+                        "Name": "Leaf 1"
+                        },
+                        {
+                        "Children": [],
+                        "Data": {
+                            "data l3": "\"value l3\"",
+                            "data l4": "\"value aaaabbbbccccdddd\""
+                        },
+                        "Name": "Leaf 2"
+                        }
+                    ],
+                    "Data": {
+                        "data 31": "\"value 31\"",
+                        "data 32": "\"value 32\""
+                    },
+                    "Name": "Node 3"
+                    },
+                    {
+                    "Children": [],
+                    "Data": {
+                        "data l5": "\"value L5\"",
+                        "data l6": "\"value l6\""
+                    },
+                    "Name": "Leaf 3"
+                    },
+                    {
+                    "Children": [],
+                    "Data": {
+                        "data 51": "\"value 51\"",
+                        "data 52": "\"value 52\""
+                    },
+                    "Name": "Leaf 4"
+                    }
+                ],
+                "Data": {
+                    "#address-cells": "<02000000>",
+                    "AAPL,phandle": "<01000000>"
+                },
+                "Name": "Node 2"
+                }
+            ],
+            "Data": {
+                "data 1": "\"value 1\"",
+                "data 2": "\"value 2\""
+            },
+            "Name": "Root node"
+        }
+
+        p.open_file = start_file
+        result = {}
+        p.recursive_fun(result)
+
+        self.assertTrue(result == expected)
+
+    def test_non_ascii_byte_anomaly(self):
+        for case_id, _ in self.sd.cases().items():
+            p = IOServiceParser(self.sd.config, case_id=case_id)
+        
+        # careful, spaces and structure is important
+        # This simulates an open file object, as if we opened it with open(path, 'rb')
+        start_file = io.BytesIO(b"""+-o Root node
+  | {
+  |   "data 1" = "value 1"
+  |   "data 2" = "value 2"
+  | }
+  | 
+  +-o Node 2
+    | {
+    |   "#address-cells" = <02000000>
+    |   "AAPL,phandle" = <01000000> 
+    | }
+    | 
+    +-o Node 3
+    | | {
+    | |   "data 31" = "value 31"
+    | |   "data 32" = "value 32"
+    | | }
+    | | 
+    | +-o Leaf 1
+    | | {
+    | |   "data l1" = "value l1"
+    | |   "data l2" = "value l2"
+    | | }
+    | |
+    | +-o Leaf 2
+    |   {
+    |     "data l3" = "value l3"
+    |     "data l4" = "value -->\xbf<--"
+    |   }
+    | 
+    +-o Leaf 3
+    | {
+    |   "data l5" = "value L5"
+    |   "data l6" = "value l6"
+    | }
+    |
+    +-o Leaf 4
+        {
+          "data 51" = "value 51"
+          "data 52" = "value 52"
+        }
+        
+""")
+        
+        expected = {
+            "Children": [
+                {
+                "Children": [
+                    {
+                    "Children": [
+                        {
+                        "Children": [],
+                        "Data": {
+                            "data l1": "\"value l1\"",
+                            "data l2": "\"value l2\""
+                        },
+                        "Name": "Leaf 1"
+                        },
+                        {
+                        "Children": [],
+                        "Data": {
+                            "data l3": "\"value l3\"",
+                            "data l4": "\"value -->?<--\""
+                        },
+                        "Name": "Leaf 2"
+                        }
+                    ],
+                    "Data": {
+                        "data 31": "\"value 31\"",
+                        "data 32": "\"value 32\""
+                    },
+                    "Name": "Node 3"
+                    },
+                    {
+                    "Children": [],
+                    "Data": {
+                        "data l5": "\"value L5\"",
+                        "data l6": "\"value l6\""
+                    },
+                    "Name": "Leaf 3"
+                    },
+                    {
+                    "Children": [],
+                    "Data": {
+                        "data 51": "\"value 51\"",
+                        "data 52": "\"value 52\""
+                    },
+                    "Name": "Leaf 4"
+                    }
+                ],
+                "Data": {
+                    "#address-cells": "<02000000>",
+                    "AAPL,phandle": "<01000000>"
+                },
+                "Name": "Node 2"
+                }
+            ],
+            "Data": {
+                "data 1": "\"value 1\"",
+                "data 2": "\"value 2\""
+            },
+            "Name": "Root node"
+        }
+
+        p.open_file = start_file
+        result = {}
+        p.recursive_fun(result)
+
+        self.assertTrue(result == expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parsers_ioservice.py
+++ b/tests/test_parsers_ioservice.py
@@ -9,7 +9,7 @@ class TestParsersIOService(SysdiagnoseTestCase):
     def test_basic_structure(self):
         for case_id, _ in self.sd.cases().items():
             p = IOServiceParser(self.sd.config, case_id=case_id)
-        
+
         # careful, spaces and structure is important
         # This simulates an open file object, as if we opened it with open(path, 'rb')
         start_file = io.BytesIO(b"""+-o Root node
@@ -54,59 +54,59 @@ class TestParsersIOService(SysdiagnoseTestCase):
           "data 52" = "value 52"
         }
         
-""")
-        
+""")  # noqa: W291, W293
+
         expected = {
             "Children": [
                 {
-                "Children": [
-                    {
                     "Children": [
                         {
-                        "Children": [],
-                        "Data": {
-                            "data l1": "\"value l1\"",
-                            "data l2": "\"value l2\""
-                        },
-                        "Name": "Leaf 1"
+                            "Children": [
+                                {
+                                    "Children": [],
+                                    "Data": {
+                                        "data l1": "\"value l1\"",
+                                        "data l2": "\"value l2\""
+                                    },
+                                    "Name": "Leaf 1"
+                                },
+                                {
+                                    "Children": [],
+                                    "Data": {
+                                        "data l3": "\"value l3\"",
+                                        "data l4": "\"value l4\""
+                                    },
+                                    "Name": "Leaf 2"
+                                }
+                            ],
+                            "Data": {
+                                "data 31": "\"value 31\"",
+                                "data 32": "\"value 32\""
+                            },
+                            "Name": "Node 3"
                         },
                         {
-                        "Children": [],
-                        "Data": {
-                            "data l3": "\"value l3\"",
-                            "data l4": "\"value l4\""
+                            "Children": [],
+                            "Data": {
+                                "data l5": "\"value L5\"",
+                                "data l6": "\"value l6\""
+                            },
+                            "Name": "Leaf 3"
                         },
-                        "Name": "Leaf 2"
+                        {
+                            "Children": [],
+                            "Data": {
+                                "data 51": "\"value 51\"",
+                                "data 52": "\"value 52\""
+                            },
+                            "Name": "Leaf 4"
                         }
                     ],
                     "Data": {
-                        "data 31": "\"value 31\"",
-                        "data 32": "\"value 32\""
+                        "#address-cells": "<02000000>",
+                        "AAPL,phandle": "<01000000>"
                     },
-                    "Name": "Node 3"
-                    },
-                    {
-                    "Children": [],
-                    "Data": {
-                        "data l5": "\"value L5\"",
-                        "data l6": "\"value l6\""
-                    },
-                    "Name": "Leaf 3"
-                    },
-                    {
-                    "Children": [],
-                    "Data": {
-                        "data 51": "\"value 51\"",
-                        "data 52": "\"value 52\""
-                    },
-                    "Name": "Leaf 4"
-                    }
-                ],
-                "Data": {
-                    "#address-cells": "<02000000>",
-                    "AAPL,phandle": "<01000000>"
-                },
-                "Name": "Node 2"
+                    "Name": "Node 2"
                 }
             ],
             "Data": {
@@ -125,7 +125,7 @@ class TestParsersIOService(SysdiagnoseTestCase):
     def test_value_overflow_anomaly(self):
         for case_id, _ in self.sd.cases().items():
             p = IOServiceParser(self.sd.config, case_id=case_id)
-        
+
         # careful, spaces and structure is important
         # This simulates an open file object, as if we opened it with open(path, 'rb')
         start_file = io.BytesIO(b"""+-o Root node
@@ -174,59 +174,59 @@ dddd
           "data 52" = "value 52"
         }
         
-""")
-        
+""")  # noqa: W291, W293
+
         expected = {
             "Children": [
                 {
-                "Children": [
-                    {
                     "Children": [
                         {
-                        "Children": [],
-                        "Data": {
-                            "data l1": "\"value l1\"",
-                            "data l2": "\"value l2\""
-                        },
-                        "Name": "Leaf 1"
+                            "Children": [
+                                {
+                                    "Children": [],
+                                    "Data": {
+                                        "data l1": "\"value l1\"",
+                                        "data l2": "\"value l2\""
+                                    },
+                                    "Name": "Leaf 1"
+                                },
+                                {
+                                    "Children": [],
+                                    "Data": {
+                                        "data l3": "\"value l3\"",
+                                        "data l4": "\"value aaaabbbbccccdddd\""
+                                    },
+                                    "Name": "Leaf 2"
+                                }
+                            ],
+                            "Data": {
+                                "data 31": "\"value 31\"",
+                                "data 32": "\"value 32\""
+                            },
+                            "Name": "Node 3"
                         },
                         {
-                        "Children": [],
-                        "Data": {
-                            "data l3": "\"value l3\"",
-                            "data l4": "\"value aaaabbbbccccdddd\""
+                            "Children": [],
+                            "Data": {
+                                "data l5": "\"value L5\"",
+                                "data l6": "\"value l6\""
+                            },
+                            "Name": "Leaf 3"
                         },
-                        "Name": "Leaf 2"
+                        {
+                            "Children": [],
+                            "Data": {
+                                "data 51": "\"value 51\"",
+                                "data 52": "\"value 52\""
+                            },
+                            "Name": "Leaf 4"
                         }
                     ],
                     "Data": {
-                        "data 31": "\"value 31\"",
-                        "data 32": "\"value 32\""
+                        "#address-cells": "<02000000>",
+                        "AAPL,phandle": "<01000000>"
                     },
-                    "Name": "Node 3"
-                    },
-                    {
-                    "Children": [],
-                    "Data": {
-                        "data l5": "\"value L5\"",
-                        "data l6": "\"value l6\""
-                    },
-                    "Name": "Leaf 3"
-                    },
-                    {
-                    "Children": [],
-                    "Data": {
-                        "data 51": "\"value 51\"",
-                        "data 52": "\"value 52\""
-                    },
-                    "Name": "Leaf 4"
-                    }
-                ],
-                "Data": {
-                    "#address-cells": "<02000000>",
-                    "AAPL,phandle": "<01000000>"
-                },
-                "Name": "Node 2"
+                    "Name": "Node 2"
                 }
             ],
             "Data": {
@@ -245,7 +245,7 @@ dddd
     def test_non_ascii_byte_anomaly(self):
         for case_id, _ in self.sd.cases().items():
             p = IOServiceParser(self.sd.config, case_id=case_id)
-        
+
         # careful, spaces and structure is important
         # This simulates an open file object, as if we opened it with open(path, 'rb')
         start_file = io.BytesIO(b"""+-o Root node
@@ -290,59 +290,59 @@ dddd
           "data 52" = "value 52"
         }
         
-""")
-        
+""")  # noqa: W291, W293
+
         expected = {
             "Children": [
                 {
-                "Children": [
-                    {
                     "Children": [
                         {
-                        "Children": [],
-                        "Data": {
-                            "data l1": "\"value l1\"",
-                            "data l2": "\"value l2\""
-                        },
-                        "Name": "Leaf 1"
+                            "Children": [
+                                {
+                                    "Children": [],
+                                    "Data": {
+                                        "data l1": "\"value l1\"",
+                                        "data l2": "\"value l2\""
+                                    },
+                                    "Name": "Leaf 1"
+                                },
+                                {
+                                    "Children": [],
+                                    "Data": {
+                                        "data l3": "\"value l3\"",
+                                        "data l4": "\"value -->?<--\""
+                                    },
+                                    "Name": "Leaf 2"
+                                }
+                            ],
+                            "Data": {
+                                "data 31": "\"value 31\"",
+                                "data 32": "\"value 32\""
+                            },
+                            "Name": "Node 3"
                         },
                         {
-                        "Children": [],
-                        "Data": {
-                            "data l3": "\"value l3\"",
-                            "data l4": "\"value -->?<--\""
+                            "Children": [],
+                            "Data": {
+                                "data l5": "\"value L5\"",
+                                "data l6": "\"value l6\""
+                            },
+                            "Name": "Leaf 3"
                         },
-                        "Name": "Leaf 2"
+                        {
+                            "Children": [],
+                            "Data": {
+                                "data 51": "\"value 51\"",
+                                "data 52": "\"value 52\""
+                            },
+                            "Name": "Leaf 4"
                         }
                     ],
                     "Data": {
-                        "data 31": "\"value 31\"",
-                        "data 32": "\"value 32\""
+                        "#address-cells": "<02000000>",
+                        "AAPL,phandle": "<01000000>"
                     },
-                    "Name": "Node 3"
-                    },
-                    {
-                    "Children": [],
-                    "Data": {
-                        "data l5": "\"value L5\"",
-                        "data l6": "\"value l6\""
-                    },
-                    "Name": "Leaf 3"
-                    },
-                    {
-                    "Children": [],
-                    "Data": {
-                        "data 51": "\"value 51\"",
-                        "data 52": "\"value 52\""
-                    },
-                    "Name": "Leaf 4"
-                    }
-                ],
-                "Data": {
-                    "#address-cells": "<02000000>",
-                    "AAPL,phandle": "<01000000>"
-                },
-                "Name": "Node 2"
+                    "Name": "Node 2"
                 }
             ],
             "Data": {


### PR DESCRIPTION
Added a recursive parser. 
Recursion is optimised to have the same call depth as the children's depth.

The parser currently handles two discovered anomalies:
    - values not respecting the structure by overflowing on the next line
    - non-ascii (nor utf-8) bytes in the IOService.txt file (replaced by '?', which is an unique character in this file)

Each node has the fields:
    - Name
    - Data
    - Children