### PR TITLE
feat(apollo): add iOS 15-18 support for telephony tables

### DIFF
--- a/src/sysdiagnose/utils/apollo_modules/powerlog_device_telephony_activity.txt
+++ b/src/sysdiagnose/utils/apollo_modules/powerlog_device_telephony_activity.txt
@@ -63,7 +63,7 @@ MODULE_NOTES=Telephony Activity
 [Database Metadata]
 DATABASE=CurrentPowerlog.PLSQL
 PLATFORM=IOS
-VERSIONS=9,10,11,12,13,14
+VERSIONS=9,10,11,12,13,14,15,16,17,18
 
 [Query Metadata]
 QUERY_NAME=powerlog_device_telephony_activity
@@ -87,3 +87,24 @@ QUERY=
       ID AS "PLBBAGENT_EVENTPOINT_TELEPHONYACTIVITY TABLE ID" 
    FROM
       PLBBAGENT_EVENTPOINT_TELEPHONYACTIVITY
+
+[SQL Query 15,16,17,18]
+QUERY=
+    SELECT
+        DATETIME(timestamp, 'UNIXEPOCH') AS TIMESTAMP,
+        airplaneMode AS "AIRPLANE MODE",
+        callStatus AS "CALL STATUS",
+        signalBars AS "SIGNAL BARS",
+        signalStrength AS "SIGNAL STRENGTH",
+        campedRat AS "CAMPED RAT",
+        currentRat AS "CURRENT RAT",
+        preferredRat AS "PREFERRED RAT",
+        activeBand AS "ACTIVE BAND",
+        dataStatus AS "DATA STATUS",
+        simStatus AS "SIM STATUS",
+        subsId AS "SUBSCRIPTION ID",
+        ID AS "BASEBANDMETRICS_TELEPHONYACTIVITY TABLE ID"
+    FROM
+        BasebandMetrics_TelephonyActivity_1_2
+    ORDER BY
+        timestamp DESC

--- a/src/sysdiagnose/utils/apollo_modules/powerlog_device_telephony_registration.txt
+++ b/src/sysdiagnose/utils/apollo_modules/powerlog_device_telephony_registration.txt
@@ -63,7 +63,7 @@ MODULE_NOTES=Records telephony registration details such AS carrier and service.
 [Database Metadata]
 DATABASE=CurrentPowerlog.PLSQL
 PLATFORM=IOS
-VERSIONS=9,10,11,12,13,14
+VERSIONS=9,10,11,12,13,14,15,16,17,18
 
 [Query Metadata]
 QUERY_NAME=powerlog_device_telephony_registration
@@ -127,3 +127,24 @@ QUERY=
         GROUP BY
 			TELEPHONYREG_ID 
       )
+
+[SQL Query 15,16,17,18]
+QUERY=
+    SELECT
+        DATETIME(timestamp, 'UNIXEPOCH') AS ADJUSTED_TIMESTAMP,
+        cellId AS "CELL ID",
+        dataInd AS "SERVICE",
+        operator AS "OPERATOR",
+        status AS "STATUS",
+        dataActive AS "DATA ACTIVE",
+        dataAttached AS "DATA ATTACHED",
+        home AS "HOME",
+        lac AS "LAC",
+        subsId AS "SUBSCRIPTION ID",
+        ID AS "BASEBANDMETRICS_TELEPHONYREGISTRATION TABLE ID"
+    FROM
+        BasebandMetrics_TelephonyRegistration_1_2
+    WHERE
+        cellId IS NOT NULL AND cellId > 0
+    ORDER BY
+        timestamp DESC


### PR DESCRIPTION
- Add BasebandMetrics_TelephonyRegistration_1_2 query for iOS 15-18
- Add BasebandMetrics_TelephonyActivity_1_2 query for iOS 15-18
- iOS 18 uses new table naming scheme (BasebandMetrics_*_1_2 vs PLBBAGENT_*)
- Enables cell tower registration and RAT activity parsing on modern iOS