### PR TITLE
fix(actions): update from Node20 to Node24

### DIFF
--- a/.github/workflows/pycodestyle.yml
+++ b/.github/workflows/pycodestyle.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ['3.11']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up unifiedlog_iterator
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -31,7 +31,7 @@ jobs:
           cargo build --release
           sudo cp ../target/release/unifiedlog_iterator /usr/local/bin/
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{matrix.python-version}}
       - name: Install Python dependencies


### PR DESCRIPTION
Update Github actions as per […/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)