### PR TITLE
[medium] fix: [mcstate_shared_profile] is_compatible() raises TypeError when the case model is unknown

### DIFF
--- a/src/sysdiagnose/parsers/mcstate_shared_profile.py
+++ b/src/sysdiagnose/parsers/mcstate_shared_profile.py
@@ -19,7 +19,9 @@ class McStateSharedProfileParser(BaseParserInterface):
     def is_compatible(self) -> bool:
         version_compatibility = super().is_compatible()
         # not compatible with Apple TV
-        device_compatibility = "AppleTV" not in self.case_model
+        # case_model is None when the case metadata carries no model; treat that as compatible
+        case_model = self.case_model or ""
+        device_compatibility = "AppleTV" not in case_model
         # both need to be compatible
         return version_compatibility and device_compatibility
 

--- a/tests/test_parsers_mcstatesharedprofile.py
+++ b/tests/test_parsers_mcstatesharedprofile.py
@@ -29,6 +29,13 @@ class TestParsersMcSettingsEvents(SysdiagnoseTestCase):
                     self.assert_has_required_fields_jsonl(item)
                 self.assert_result_summary_consistent(p, result)
 
+    def test_is_compatible_without_case_model(self):
+        """A case whose metadata carries no "model" must not crash is_compatible()."""
+        case = {"case_id": "mcstate-shared-profile-no-model", "ios_version": "16.0"}
+        p = McStateSharedProfileParser(self.sd.config, case=case)
+        self.assertIsNone(p.case_model)
+        self.assertIsInstance(p.is_compatible(), bool)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## BLUF

- **Priority: medium.** `McStateSharedProfileParser.is_compatible()` raises `TypeError: argument of type 'NoneType' is not iterable` whenever the case metadata carries no `model`.
- **`case_model` is documented as optional.** `BaseInterface.case_model` is typed `str | None` and returns `self.case.get("model")`, so `None` is a legitimate, expected value — but line 22 does `"AppleTV" not in self.case_model` with no guard.
- **The blast radius is the whole run, not this parser.** `BaseInterface._execute_and_write()` calls `is_compatible()` *outside* its own `try/except` crash guard, so the `TypeError` is not caught, escapes `Sysdiagnose.parse()`, and aborts the entire invocation — every remaining parser and every remaining case is skipped.
- **Fix:** coalesce to `""` before the substring test. A case with an unknown model is treated as compatible, which is the safe default for a forensic tool — better to run the parser and produce nothing than to skip it silently.
- **Scope:** 3 changed lines in one parser, plus a regression test. No base-class change.

## Reproducing

Any case whose `cases.json` entry has no `model` key — which happens whenever `get_case_metadata()` could not determine the device model from the archive:

```python
case = {"case_id": "no-model", "ios_version": "16.0"}
McStateSharedProfileParser(config, case=case).is_compatible()
# TypeError: argument of type 'NoneType' is not iterable
```

## The fix

```python
# case_model is None when the case metadata carries no model; treat that as compatible
case_model = self.case_model or ""
device_compatibility = "AppleTV" not in case_model
```

## Test

`test_is_compatible_without_case_model` builds a case dict with no `model`, asserts `case_model` is `None`, and asserts `is_compatible()` returns a `bool` instead of raising. Verified to fail on `main` with the exact `TypeError` above and pass with this change.

## Note

Three sibling parsers (`itunesstore`, `mobilebackup`, `networkextension`) carry the identical unguarded pattern. They are submitted as separate PRs so each can be reviewed and reverted independently.
