### PR TITLE
[high] fix: [spindumpnosymbols] blanket except IndexError reports a total parse failure as an empty, successful result

### DIFF
--- a/src/sysdiagnose/parsers/spindumpnosymbols.py
+++ b/src/sysdiagnose/parsers/spindumpnosymbols.py
@@ -41,54 +41,48 @@ class SpindumpNoSymbolsParser(BaseParserInterface):
 
     @staticmethod
     def parse_file(path: str) -> list:
-        try:
-            with open(path) as f_in:
-                # init section
-                headers = []
-                processes_raw = []
-                status = "headers"
+        with open(path) as f_in:
+            # init section
+            headers = []
+            processes_raw = []
+            status = "headers"
 
-                # stripping
-                for line in f_in:
-                    if line.strip() == "No samples":
-                        status = "empty"
-                        # Since the rest is just 'binary format', we ignore the rest of the file.
-                        break
-                    elif (
-                        line.strip() == ""
-                        or line.strip() == "Heavy format: stacks are sorted by count"
-                        or line.strip() == "Use -i and -timeline to re-report with chronological sorting"
-                    ):
-                        continue
-                    elif line.strip() == "------------------------------------------------------------":
-                        status = "processes_raw"
-                        continue
-                    elif line.strip() == "Spindump binary format":
-                        status = "binary"
-                        continue
-                    elif status == "headers":
-                        headers.append(line.strip())
-                        continue
-                    elif status == "processes_raw":
-                        processes_raw.append(line.strip())
-                        continue
+            # stripping
+            for line in f_in:
+                if line.strip() == "No samples":
+                    status = "empty"
+                    # Since the rest is just 'binary format', we ignore the rest of the file.
+                    break
+                elif (
+                    line.strip() == ""
+                    or line.strip() == "Heavy format: stacks are sorted by count"
+                    or line.strip() == "Use -i and -timeline to re-report with chronological sorting"
+                ):
+                    continue
+                elif line.strip() == "------------------------------------------------------------":
+                    status = "processes_raw"
+                    continue
+                elif line.strip() == "Spindump binary format":
+                    status = "binary"
+                    continue
+                elif status == "headers":
+                    headers.append(line.strip())
+                    continue
+                elif status == "processes_raw":
+                    processes_raw.append(line.strip())
+                    continue
 
-                # call parsing function per section
-                events = []
-                if status != "empty":
-                    basic = SpindumpNoSymbolsParser.parse_basic(headers)
-                    basic["message"] = f"spindump {basic['data']['data_source']}"
-                    events.append(basic)
-                    events.extend(
-                        SpindumpNoSymbolsParser.parse_processes(processes_raw, start_timestamp=basic["datetime"])
-                    )
-                # Logging
-                logger.debug(f"{len(events)} events retrieved", extra={"num_events": len(events)})
+            # call parsing function per section
+            events = []
+            if status != "empty":
+                basic = SpindumpNoSymbolsParser.parse_basic(headers)
+                basic["message"] = f"spindump {basic['data']['data_source']}"
+                events.append(basic)
+                events.extend(SpindumpNoSymbolsParser.parse_processes(processes_raw, start_timestamp=basic["datetime"]))
+            # Logging
+            logger.debug(f"{len(events)} events retrieved", extra={"num_events": len(events)})
 
-                return events
-
-        except IndexError:
-            return []
+            return events
 
     @staticmethod
     def parse_basic(data: list) -> dict:

--- a/tests/test_parsers_spindumpnosymbols.py
+++ b/tests/test_parsers_spindumpnosymbols.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import patch
 
 from sysdiagnose.parsers.spindumpnosymbols import SpindumpNoSymbolsParser
 from tests import SysdiagnoseTestCase
@@ -240,6 +241,20 @@ class TestParsersSpindumpnosymbols(SysdiagnoseTestCase):
         }
         result = SpindumpNoSymbolsParser.parse_thread(lines)
         self.assertDictEqual(expected_result, result)
+
+    def test_parse_file_does_not_swallow_indexerror(self):
+        """A parse failure must surface as an error, not as an empty successful result."""
+        path = os.path.join(self.tmp_folder, "spindump-nosymbols.txt")
+        with open(path, "w") as f:
+            f.write("Date/Time:        2023-05-24 13:29:15.759 -0700\n")
+            f.write("------------------------------------------------------------\n")
+            f.write("Process:          accessoryd [176]\n")
+
+        with (
+            patch.object(SpindumpNoSymbolsParser, "parse_basic", side_effect=IndexError("boom")),
+            self.assertRaises(IndexError),
+        ):
+            SpindumpNoSymbolsParser.parse_file(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## BLUF

- **Priority: high.** `SpindumpNoSymbolsParser.parse_file()` wraps its entire body in `try: ... except IndexError: return []`. Any indexing error anywhere in the parse — including inside `parse_basic()`, `parse_processes()`, `parse_process()` and `parse_thread()` — is converted into an empty result.
- **This is a forensic-soundness bug, not a robustness nicety.** The empty list is returned with **no log line**, so the base class records `num_errors=0` and a successful `ExecutionStatus`. An analyst sees `spindumpnosymbols.jsonl` present, zero events, and a green summary — indistinguishable from a device that genuinely had no spindump activity.
- **The swallow is far wider than the error it was presumably written for.** `execute()` already guards the empty-`get_log_files()` case explicitly (`logger.warning` + `return []`), so this `except` is not protecting the `log_files[0]` access — it only masks failures deep inside the parsing helpers.
- **Fix:** remove the blanket `except`. `BaseInterface._execute_and_write()` already has a crash guard that catches `Exception`, calls `logger.exception()`, and records `add_errors=1` — the correct destination for an unexpected `IndexError`. Behaviour on well-formed input is unchanged.
- **Scope:** one parser; the `try:` line and the two-line `except` removed, body dedented. Plus a regression test.

## Before / after on a malformed file

| | `main` | this PR |
|---|---|---|
| events written | `[]` | `[]` |
| log output | *(nothing)* | `Execution crashed: ...` + traceback |
| `num_errors` | `0` | `1` |
| summary status | success | error |

## Why not `logger.warning()` + `return []`

`CONTRIBUTING.md` asks for `logger.warning()` over raising **for expected conditions** — a missing file, empty data. An `IndexError` raised from inside `parse_thread()` is not an expected condition; it means the spindump grammar assumed by the parser did not hold. Surfacing it as a module error is what lets that get fixed, and the base class already formats it correctly.

## Test

`test_parse_file_does_not_swallow_indexerror` patches `parse_basic` to raise `IndexError` and asserts `parse_file` propagates it. Verified to fail on `main` with `AssertionError: IndexError not raised` and pass with this change. The five existing `spindumpnosymbols` tests are unaffected.
