### PR TITLE
[high] fix: [main] one parser crash aborts every remaining parser and every remaining case

### DIFF
--- a/src/sysdiagnose/__main__.py
+++ b/src/sysdiagnose/__main__.py
@@ -197,6 +197,14 @@ def main() -> None:
                         extra={"parser": parser, "result": "skipped"},
                     )
                     continue
+                except Exception:
+                    # a crash in one parser must not abort the remaining parsers or the remaining cases
+                    logger.exception(
+                        f"Parser '{parser}' crashed, skipping",
+                        extra={"parser": parser, "result": "error"},
+                    )
+                    print("  → crashed, see log")
+                    continue
                 duration_str = f" ({summary.duration:.2f}s)" if summary.duration is not None else ""
                 print(
                     f"  → {summary.status}: {summary.num_events} events, {summary.num_errors} errors, {summary.num_warnings} warnings{duration_str}"  # noqa: E501
@@ -249,6 +257,14 @@ def main() -> None:
                         f"Analyser '{analyser}' is not implemented yet, skipping",
                         extra={"analyser": analyser, "result": "skipped"},
                     )
+                    continue
+                except Exception:
+                    # a crash in one analyser must not abort the remaining analysers or the remaining cases
+                    logger.exception(
+                        f"Analyser '{analyser}' crashed, skipping",
+                        extra={"analyser": analyser, "result": "error"},
+                    )
+                    print("  → crashed, see log")
                     continue
                 duration_str = f" ({summary.duration:.2f}s)" if summary.duration is not None else ""
                 print(

--- a/tests/test_main_crash_isolation.py
+++ b/tests/test_main_crash_isolation.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sysdiagnose.utils.summary import ExecutionStatus, ResultSummary
+
+
+def _ok_summary():
+    s = ResultSummary(status=ExecutionStatus.SUCCESS, num_events=1)
+    s.duration = 0.0
+    return s
+
+
+class TestMainCrashIsolation(unittest.TestCase):
+    """One crashing parser/analyser must not abort the remaining ones or the remaining cases."""
+
+    def _run_main(self, mode, attr, names):
+        attempted = []
+
+        def _side_effect(name, case_id):
+            attempted.append((name, case_id))
+            if name == names[0]:
+                raise ValueError("boom")
+            return _ok_summary()
+
+        sd = MagicMock()
+        sd.config.get_parsers.return_value = dict.fromkeys(names)
+        sd.config.get_analysers.return_value = dict.fromkeys(names)
+        sd.get_case_ids.return_value = ["case1", "case2"]
+        setattr(sd, attr, MagicMock(side_effect=_side_effect))
+
+        argv = ["sysdiagnose", "-c", "all", mode, "all"]
+        with (
+            patch("sysdiagnose.__main__.Sysdiagnose", return_value=sd),
+            patch("sysdiagnose.__main__.sys.argv", argv),
+            patch("sysdiagnose.__main__.case_csv_to_case_ids", return_value=["case1", "case2"]),
+        ):
+            from sysdiagnose.__main__ import main
+
+            main()
+        return attempted
+
+    def test_parse_continues_after_a_crashing_parser(self):
+        attempted = self._run_main("parse", "parse", ["boom_parser", "good_parser"])
+        # both parsers attempted, for both cases -- the crash did not abort the run
+        self.assertEqual(
+            [
+                ("boom_parser", "case1"),
+                ("good_parser", "case1"),
+                ("boom_parser", "case2"),
+                ("good_parser", "case2"),
+            ],
+            attempted,
+        )
+
+    def test_analyse_continues_after_a_crashing_analyser(self):
+        attempted = self._run_main("analyse", "analyse", ["boom_analyser", "good_analyser"])
+        self.assertEqual(
+            [
+                ("boom_analyser", "case1"),
+                ("good_analyser", "case1"),
+                ("boom_analyser", "case2"),
+                ("good_analyser", "case2"),
+            ],
+            attempted,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## BLUF

- **Priority: high.** The `parse` and `analyse` driver loops in `__main__.py` catch only `NotImplementedError`. Any other exception from `sd.parse()` / `sd.analyse()` propagates out of `main()` and **terminates the whole invocation** — every remaining parser/analyser and every remaining case is skipped.
- **The base class does not cover this.** `BaseInterface._execute_and_write()` has a crash guard, but it wraps only the `execute()` call. Everything before it — `is_compatible()`, the `BaseInterface.__init__` glob, `get_log_files()` — runs unguarded, and a failure there reaches the CLI loop.
- **This is the amplifier for whole classes of single-module bugs.** A `TypeError` in one parser's `is_compatible()` (four parsers currently raise one when the case model is unknown) does not degrade that parser — it silently ends the run, and on `--case_id all` it takes every later case with it.
- **Worst on batch runs**, which is the normal way this tool is used: `sysdiag -c all parse all` on 40 cases can stop at case 3, parser 7, with 33 cases never touched and no non-zero exit distinguishing that from success.
- **Fix:** add `except Exception:` to both loops — `logger.exception()` for the traceback, one line on stdout, `continue`. No exit-code semantics are changed.
- **Scope:** two symmetric 8-line blocks in `__main__.py`, plus a new test module.

## The fix

```python
except Exception:
    # a crash in one parser must not abort the remaining parsers or the remaining cases
    logger.exception(
        f"Parser '{parser}' crashed, skipping",
        extra={"parser": parser, "result": "error"},
    )
    print("  → crashed, see log")
    continue
```

Applied identically to the analyse loop.

## Test

`tests/test_main_crash_isolation.py` drives `main()` with a mocked `Sysdiagnose` whose `parse`/`analyse` raises `ValueError` for the first module and succeeds for the second, across two cases. It asserts all four (module, case) combinations are attempted.

Verified to fail on `main` with `ValueError: boom` escaping `main()` after the very first call, and to pass with this change.
