### PR TITLE
[high] fix: [base] a failed write leaves a truncated output file that is served as a complete cached result

### DIFF
--- a/src/sysdiagnose/utils/base.py
+++ b/src/sysdiagnose/utils/base.py
@@ -367,7 +367,21 @@ class BaseInterface(ABC):
             self._result = [] if self.format == "jsonl" else {}
             return self._result, self._result_summary
 
-        num_events = self._write_result(result, indent=indent)
+        try:
+            num_events = self._write_result(result, indent=indent)
+        except Exception as ex:
+            # A partially written output file must never be served as a complete cached result:
+            # output_exists() would be true and _load_output() would return the truncated data.
+            logger.exception(f"Writing result failed: {ex}")
+            try:
+                os.remove(self.output_file)
+            except OSError:
+                logger.warning(f"Could not remove partially written {self.output_file}")
+            handler.update(num_events=0, add_errors=1, end=True)
+            self._result_summary = handler.get()
+            self._result = [] if self.format == "jsonl" else {}
+            return self._result, self._result_summary
+
         handler.update(num_events=num_events, end=True)
         return self._result, handler.get()
 

--- a/tests/test_base_write_failure.py
+++ b/tests/test_base_write_failure.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+from sysdiagnose.utils.base import BaseParserInterface
+from tests import SysdiagnoseTestCase
+
+
+class _ExplodingParser(BaseParserInterface):
+    """Yields a couple of good events, then fails part-way through the write."""
+
+    description = "test parser that fails during write"
+    format = "jsonl"
+    module_name = "exploding"
+
+    def get_log_files(self) -> list:
+        return []
+
+    def execute(self):
+        def _gen():
+            yield {"message": "one", "datetime": "2023-05-24T13:29:15+00:00", "timestamp_desc": "t", "module": "e"}
+            yield {"message": "two", "datetime": "2023-05-24T13:29:16+00:00", "timestamp_desc": "t", "module": "e"}
+            raise RuntimeError("disk full")
+
+        return _gen()
+
+
+class TestBaseWriteFailure(SysdiagnoseTestCase):
+    def test_partial_write_is_not_served_as_a_cached_result(self):
+        case = {"case_id": "base-write-failure", "ios_version": "16.0"}
+        p = _ExplodingParser(__file__, self.sd.config, case=case)
+
+        result, summary = p._execute_and_write()
+
+        # the truncated output file must be gone, so output_exists() cannot serve it as a cache
+        self.assertFalse(os.path.exists(p.output_file))
+        self.assertFalse(p.output_exists())
+        # the failure must be recorded, not reported as a clean empty run
+        # >= 1: the logged exception is also counted by the attached ResultSummaryLogHandler
+        self.assertGreaterEqual(summary.num_errors, 1)
+        self.assertEqual(0, summary.num_events)
+        self.assertEqual([], result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## BLUF

- **Priority: high.** In `BaseInterface._execute_and_write()`, the `_write_result()` call sits **outside** the `try/except` that guards `execute()`. If the write fails part-way — a raising generator, a disk-full `OSError`, a non-serialisable value reaching `json.dumps` — three things go wrong at once.
- **1. A truncated output file is left on disk and later served as a complete result.** `get_result()` checks `output_exists()`, finds the partial file, and returns `_load_output()` **without re-running the parser**. The analyst gets a silently short event list presented as the full parse. For a forensic tool this is the worst failure mode: not an error, but confidently wrong output.
- **2. The summary is never written.** The exception escapes `_execute_and_write()` before `save_result_summary()` in `save_result()`, so no `summary-<module>.json` records that anything went wrong.
- **3. The log handler leaks.** `ResultSummaryExecutionHandler.start()` calls `logger.addHandler()`; the matching `get()` never runs, so the handler stays attached to the **global** logger and keeps counting every subsequent module's records.
- **Fix:** wrap `_write_result()` in the same guard, delete the partial output file so `output_exists()` is false, and finalise the handler with `add_errors=1`. A failed write now looks exactly like a failed `execute()`.
- **Scope:** one method in `utils/base.py` (+15 lines), plus a new test module. Behaviour on a successful write is byte-for-byte unchanged.

## Failure path today

```python
result = self.execute()          # guarded
num_events = self._write_result(result, indent=indent)   # NOT guarded  <-- line 370
```

For `format = "jsonl"`, `_write_result` iterates the generator *inside* `open(self.output_file, "w")`. A generator that raises on its 500th event leaves 499 events in a well-formed `.jsonl` file that nothing marks as incomplete.

## The fix

```python
try:
    num_events = self._write_result(result, indent=indent)
except Exception as ex:
    # A partially written output file must never be served as a complete cached result:
    # output_exists() would be true and _load_output() would return the truncated data.
    logger.exception(f"Writing result failed: {ex}")
    try:
        os.remove(self.output_file)
    except OSError:
        logger.warning(f"Could not remove partially written {self.output_file}")
    handler.update(num_events=0, add_errors=1, end=True)
    self._result_summary = handler.get()
    self._result = [] if self.format == "jsonl" else {}
    return self._result, self._result_summary
```

## Test

`tests/test_base_write_failure.py` defines a `jsonl` parser whose generator yields two good events and then raises `RuntimeError`. It asserts the output file does not exist afterwards, `output_exists()` is false, `num_errors >= 1` and `num_events == 0`.

Verified to fail on `main` with `RuntimeError: disk full` escaping `_execute_and_write()`, and to pass with this change.

Full suite: 125 passed, 9 failed, 2 skipped — the same 9 pre-existing failures as on `main` at `270a58c`, plus this new test.
