### PR TITLE
[medium] fix: [main] get_case_metadata raises UnboundLocalError, making the ioreg/SystemVersion fallback unreachable

### DIFF
--- a/src/sysdiagnose/__init__.py
+++ b/src/sysdiagnose/__init__.py
@@ -199,11 +199,24 @@ class Sysdiagnose:
         from sysdiagnose.parsers.sys import SystemVersionParser
 
         if os.path.isdir(source_file):
-            # First try remotectl_dumpstate method
+            # Both are consumed below and by the ioreg/SystemVersion fallback, so they must always be
+            # bound -- otherwise a failure here raises UnboundLocalError and the fallback is unreachable.
+            sysdiagnose_date_utc = None
+            remotectl_dumpstate_json = None
+
+            # The date and the dumpstate come from different files: a failure to read one must not
+            # discard the other.
             try:
                 sysdiagnose_log_file = os.path.join(source_file, "sysdiagnose.log")
                 sysdiagnose_date = BaseInterface.get_sysdiagnose_creation_datetime_from_file(sysdiagnose_log_file)
                 sysdiagnose_date_utc = sysdiagnose_date.astimezone(UTC)
+            except Exception as e:
+                logger.warning(
+                    f"Problem while processsing folder {source_file} for sysdiagnose.log: {e!s}", exc_info=True
+                )
+
+            # First try remotectl_dumpstate method
+            try:
                 remotectl_dumpstate_file = os.path.join(source_file, "remotectl_dumpstate.txt")
                 remotectl_dumpstate_json = RemotectlDumpstateParser.parse_file(remotectl_dumpstate_file)
             except Exception as e:

--- a/tests/test_case_metadata_fallback.py
+++ b/tests/test_case_metadata_fallback.py
@@ -1,0 +1,34 @@
+import os
+import tempfile
+import unittest
+
+from sysdiagnose import Sysdiagnose
+
+
+class TestCaseMetadataFallback(unittest.TestCase):
+    """
+    get_case_metadata() must not raise when remotectl_dumpstate.txt is missing or unparseable.
+
+    On main, `remotectl_dumpstate_json` and `sysdiagnose_date_utc` are only bound inside the try
+    block, but are read unconditionally after it -- so any failure there raises UnboundLocalError
+    and the documented ioreg/SystemVersion fallback below can never execute.
+    """
+
+    def test_missing_remotectl_dumpstate_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as folder:
+            # a sysdiagnose folder with neither remotectl_dumpstate.txt nor a readable sysdiagnose.log
+            metadata = Sysdiagnose.get_case_metadata(folder)
+        self.assertIsNone(metadata)
+
+    def test_unparseable_remotectl_dumpstate_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as folder:
+            with open(os.path.join(folder, "sysdiagnose.log"), "w") as f:
+                f.write("not a real sysdiagnose log\n")
+            with open(os.path.join(folder, "remotectl_dumpstate.txt"), "w") as f:
+                f.write("garbage\n")
+            metadata = Sysdiagnose.get_case_metadata(folder)
+        self.assertIsNone(metadata)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## BLUF

- **Priority: medium.** `Sysdiagnose.get_case_metadata()` binds `sysdiagnose_date_utc` and `remotectl_dumpstate_json` **inside** a `try` block, then reads both **unconditionally after** it. Any failure in that block leaves the names unbound, so the very next line raises `UnboundLocalError`.
- **The consequence is that the documented fallback is dead code.** The `except` logs a warning and falls through, clearly intending the ioreg/SystemVersion path below to take over. It never can: the `UnboundLocalError` is raised before execution reaches it. The "As a backup use ioreg and sys method" branch has never run in this code path.
- **It also does not return `None` — it raises.** `get_case_metadata` is documented to return "dictionary with metadata or None if the file is invalid". Callers that handle `None` still get an exception, and `create_case` aborts on an archive that the fallback could have handled.
- **Two unrelated files are coupled in one `try`.** The date comes from `sysdiagnose.log`, the dumpstate from `remotectl_dumpstate.txt`. Today a failure to read *either* discards *both* — including the date the fallback itself needs.
- **Fix:** pre-bind both to `None` and split the block in two, so each file's failure is independent and the fallback becomes reachable.
- **Scope:** one function in `__init__.py`, plus a new test module. No behaviour change when `remotectl_dumpstate.txt` parses cleanly.

## The bug

```python
try:
    sysdiagnose_date = BaseInterface.get_sysdiagnose_creation_datetime_from_file(sysdiagnose_log_file)
    sysdiagnose_date_utc = sysdiagnose_date.astimezone(UTC)
    remotectl_dumpstate_json = RemotectlDumpstateParser.parse_file(remotectl_dumpstate_file)
except Exception as e:
    logger.warning(...)          # falls through, names never bound

metadata = Sysdiagnose.metadata_from_remotectl_sysdiagnose_data(
    remotectl_dumpstate_json, sysdiagnose_date_utc, source_file   # UnboundLocalError
)
```

`metadata_from_remotectl_sysdiagnose_data` already handles a falsy `remotectl_dumpstate_json` correctly (`if remotectl_dumpstate_json and ...` → returns `None`), so pre-binding to `None` gives exactly the fall-through the author intended.

## Test

`tests/test_case_metadata_fallback.py` calls `get_case_metadata()` on a folder with no `remotectl_dumpstate.txt`, and on one with an unparseable one, asserting `None` is returned rather than an exception raised.

Verified to fail on `main` with `UnboundLocalError: cannot access local variable 'remotectl_dumpstate_json'` and pass with this change.
