### PR TITLE
[medium] fix: [apollo] raw sqlite BLOB values reach json.dumps and abort the module

### DIFF
--- a/src/sysdiagnose/utils/apollo.py
+++ b/src/sysdiagnose/utils/apollo.py
@@ -68,6 +68,7 @@ import sqlite3
 from datetime import UTC, datetime
 
 from sysdiagnose.utils.base import Event
+from sysdiagnose.utils.misc import json_serializable
 
 default_mod_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "apollo_modules")
 
@@ -192,7 +193,8 @@ class Apollo:
                             ),
                             module=self.saf_module,
                             timestamp_desc=module_query["activity"],
-                            data=item,
+                            # sqlite BLOB columns come back as bytes, which json.dumps cannot encode
+                            data=json_serializable(item),
                         )
                         results.append(event.to_dict())
                     except TypeError:

--- a/tests/test_apollo_blob.py
+++ b/tests/test_apollo_blob.py
@@ -1,0 +1,62 @@
+import json
+import logging
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from sysdiagnose.utils.apollo import Apollo
+
+
+class TestApolloBlob(unittest.TestCase):
+    """sqlite BLOB columns must not reach json.dumps as raw bytes."""
+
+    def _build_db_and_module(self, tmp):
+        db_path = os.path.join(tmp, "test.db")
+        con = sqlite3.connect(db_path)
+        con.execute("CREATE TABLE t (ts TEXT, payload BLOB)")
+        con.execute("INSERT INTO t VALUES (?, ?)", ("2023-05-24 13:29:15", b"\x89PNG\r\n\x1a\n\xff\xfe"))
+        con.commit()
+        con.close()
+
+        mod_dir = os.path.join(tmp, "modules")
+        os.makedirs(mod_dir)
+        with open(os.path.join(mod_dir, "test.txt"), "w") as f:
+            f.write(
+                "[Module Metadata]\n"
+                "AUTHOR = test\n"
+                "MODULE_NAME = test_module\n"
+                "LAST_UPDATED = 2024-01-01\n"
+                "\n"
+                "[Database Metadata]\n"
+                "DATABASE = test.db\n"
+                "\n"
+                "[Query Metadata]\n"
+                "QUERY_NAME = test_query\n"
+                "ACTIVITY = test activity\n"
+                "KEY_TIMESTAMP = ts\n"
+                "\n"
+                "[SQL Query 14.0]\n"
+                "QUERY = \n"
+                "    SELECT ts, payload FROM t\n"
+            )
+        return db_path, mod_dir
+
+    def test_blob_column_is_json_serialisable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path, mod_dir = self._build_db_and_module(tmp)
+            a = Apollo(
+                logger=logging.getLogger("test"),
+                saf_module="test",
+                mod_dir=mod_dir,
+                os_version="14.0",
+            )
+            results = a.parse_db(db_fname=db_path, db_type="test.db")
+
+        self.assertTrue(results, "expected at least one event")
+        # on main this raises TypeError: Object of type bytes is not JSON serializable
+        json.dumps(results)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## BLUF

- **Priority: medium.** `Apollo.parse_db()` builds `item = dict(zip(headers, row))` straight from `sqlite3` rows and hands it to `Event(data=item)` without normalising the values. A `BLOB` column arrives as Python `bytes`, which `json.dumps` cannot encode.
- **The failure lands well away from the cause.** Nothing raises in `apollo.py`; the `TypeError: Object of type bytes is not JSON serializable` surfaces later in `BaseInterface._write_result()`, so the traceback points at the base class rather than at the database column responsible.
- **The whole module's output is lost, not just the offending row.** The exception escapes mid-write, so every event Apollo had already produced for that database goes with it.
- **The project already has the right tool and Apollo just isn't using it.** `misc.json_serializable` is a `singledispatch` normaliser with a registered `bytes` handler that decodes UTF-8 where possible and falls back to base64. Every other jsonl producer routes through it.
- **Fix:** one call — `data=json_serializable(item)`.
- **Scope:** one import and one changed line in `utils/apollo.py`, plus a new test module.

## The fix

```python
timestamp_desc=module_query["activity"],
# sqlite BLOB columns come back as bytes, which json.dumps cannot encode
data=json_serializable(item),
```

`_handle_bytes` does `value.decode(errors="strict")` and falls back to `base64.b64encode(...)`, so binary column contents are preserved in a readable, round-trippable form rather than crashing the module.

## Note on the existing `except TypeError`

`parse_db` already catches `TypeError` around the `Event` construction, but that guard is for timestamp parsing (`datetime.fromisoformat`) and logs "Problem with timestamp parsing". It does not fire here: the `bytes` value is accepted into the `Event` without complaint and only fails at serialisation time, outside this function.

## Test

`tests/test_apollo_blob.py` builds a temporary sqlite database with a `BLOB` column holding non-UTF-8 bytes plus a matching Apollo module definition, runs `parse_db()`, and calls `json.dumps()` on the result.

Verified to fail on `main` with `TypeError: Object of type bytes is not JSON serializable` and pass with this change.
