### PR TITLE
[medium] fix: [brctl] container values containing a space are silently truncated to their first word

### DIFF
--- a/src/sysdiagnose/parsers/brctl.py
+++ b/src/sysdiagnose/parsers/brctl.py
@@ -31,20 +31,29 @@ class BrctlParser(BaseParserInterface):
             return {}
         return BrctlParser.parse_folder(log_files[0])
 
+    # Container list values come in three shapes:
+    #   id:com.apple.CloudDocs                      -- a bare token
+    #   localizedName:'iCloud Drive'                -- single-quoted, may contain spaces
+    #   [Private: inInitialState] / [Public:]       -- bracketed
+    # `clients` is a comma-separated list that runs to the end of the line.
+    CONTAINER_KEYS = ("id", "localizedName", "documents", "Public", "Private", "clients")
+    CONTAINER_VALUE_RE = re.compile(rf"({'|'.join(CONTAINER_KEYS)}):\s*('[^']*'|\[[^\]]*\]|[^ \[]*)")
+    CONTAINER_CLIENTS_RE = re.compile(r"clients:\s*(.*)$")
+
     @staticmethod
     def parselistfile(container_list_file):
         containers = {"containers": []}
-        result = []
         with open(container_list_file[0]) as f:
-            keys = ["id", "localizedName", "documents", "Public", "clients"]
             for l_line in f:
                 line = l_line.strip()
-                line = line.replace("Mobile Documents", "Mobile_Documents")
-                keys = ["id", "localizedName", "documents", "Public", "Private", "clients"]
-                values = re.findall(rf"({'|'.join(keys)}):\s*([^ \[]+|\[[^\]]*\])", line)
-                result = {k: v.strip("[]") for k, v in values}
+                values = BrctlParser.CONTAINER_VALUE_RE.findall(line)
+                result = {k: v.strip("[]'") for k, v in values}
                 if result != {}:
-                    result["documents"] = result["documents"].replace("Mobile_Documents", "Mobile Documents")
+                    # `clients` is space-separated as well as comma-separated, so it has to be
+                    # taken to the end of the line rather than to the first space.
+                    clients = BrctlParser.CONTAINER_CLIENTS_RE.search(line)
+                    if clients:
+                        result["clients"] = clients.group(1).strip()
                     containers["containers"].append(result)
             return containers
 

--- a/tests/test_parsers_brctl.py
+++ b/tests/test_parsers_brctl.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 from sysdiagnose.parsers.brctl import BrctlParser
@@ -34,6 +35,42 @@ class TestParsersBrctl(SysdiagnoseTestCase):
                     self.assertTrue("app_library_id" in result)
                     self.assertTrue("app_ids" in result)
                 self.assert_result_summary_consistent(p, result)
+
+    # real lines from brctl-container-list.txt of an iOS 16 sysdiagnose
+    SAMPLE = (
+        "listing 17 containers for account 89695A59-F596-4E3A-952F-034A30421C79:\n"
+        "  id:com.apple.shoebox localizedName:'Wallet' "
+        "documents:'/private/var/mobile/Library/Mobile Documents/com~apple~shoebox/Documents' "
+        "[Private: inInitialState] clients: com.apple.passd, com.apple.PassbookUIService, com.apple.Passbook\n"
+        "  id:com.apple.CloudDocs localizedName:'iCloud Drive' "
+        "documents:'/private/var/mobile/Library/Mobile Documents/com~apple~CloudDocs' [Public:] clients: \n"
+    )
+
+    def test_parselistfile_keeps_values_containing_spaces(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "brctl-container-list.txt")
+            with open(path, "w") as f:
+                f.write(self.SAMPLE)
+            containers = BrctlParser.parselistfile([path])["containers"]
+
+        self.assertEqual(2, len(containers))
+
+        shoebox, clouddocs = containers
+        # a localizedName with a space must not be truncated at the space
+        self.assertEqual("Wallet", shoebox["localizedName"])
+        self.assertEqual("iCloud Drive", clouddocs["localizedName"])
+        # the documents path must survive without the Mobile_Documents round-trip hack
+        self.assertEqual(
+            "/private/var/mobile/Library/Mobile Documents/com~apple~shoebox/Documents",
+            shoebox["documents"],
+        )
+        # clients is a comma-separated list running to the end of the line, not just its first entry
+        self.assertEqual(
+            "com.apple.passd, com.apple.PassbookUIService, com.apple.Passbook",
+            shoebox["clients"],
+        )
+        self.assertEqual("inInitialState", shoebox["Private"])
+        self.assertEqual("", clouddocs["clients"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## BLUF

- **Priority: medium.** `BrctlParser.parselistfile()` matches container values with `([^ \[]+|\[[^\]]*\])`, which stops at the first space. Real `brctl-container-list.txt` values are **single-quoted and routinely contain spaces**, so they are silently truncated.
- **Confirmed against the project's own iOS 16 test archive**, not hypothetically. `localizedName:'iCloud Drive'` is parsed as `'iCloud`. `clients: com.apple.passd, com.apple.PassbookUIService, com.apple.Passbook` is parsed as `com.apple.passd,` — two of the three clients are dropped, and a trailing comma is kept.
- **Every value also retains its surrounding quotes** (`"localizedName": "'Wallet'"`), because `.strip("[]")` does not strip `'`.
- **The `Mobile Documents` → `Mobile_Documents` substitution is a workaround for this same bug** — a targeted patch for the one path that was noticed. It only ever covered that single literal; any other space-bearing value was left broken.
- **Fix:** match quoted values as a unit, strip the quotes, and read `clients` to the end of the line. The `Mobile_Documents` round-trip is then unnecessary and is removed.
- **Scope:** one method in `brctl.py`, plus a regression test built from real sample lines.

## Before / after, on the iOS 16 test archive

| field | `main` | this PR |
|---|---|---|
| `localizedName` | `'Wallet'` | `Wallet` |
| `localizedName` (CloudDocs) | `'iCloud` | `iCloud Drive` |
| `clients` | `com.apple.passd,` | `com.apple.passd, com.apple.PassbookUIService, com.apple.Passbook` |
| `documents` | correct *(via the hack)* | correct *(structurally)* |

## The fix

```python
CONTAINER_KEYS = ("id", "localizedName", "documents", "Public", "Private", "clients")
CONTAINER_VALUE_RE = re.compile(rf"({'|'.join(CONTAINER_KEYS)}):\s*('[^']*'|\[[^\]]*\]|[^ \[]*)")
CONTAINER_CLIENTS_RE = re.compile(r"clients:\s*(.*)$")
```

Three value shapes are matched explicitly — single-quoted (may contain spaces), bracketed, bare token — and `clients` is taken to the end of the line because it is both space- and comma-separated.

## Note on the output schema

`localizedName` and `documents` no longer carry surrounding `'` characters, and `clients` now holds the full list rather than its first entry. Both are corrections of truncated/garbled values rather than new fields, but they do change the emitted strings, so this is worth a deliberate look during review.

## Test

`test_parselistfile_keeps_values_containing_spaces` uses two verbatim lines from the iOS 16 archive and asserts the space-bearing `localizedName`, the full `documents` path, and the complete `clients` list.

Verified to fail on `main` with `AssertionError: 'Wallet' != "'Wallet'"` and pass with this change. The existing `test_parsebrctl` is unaffected.
