### PR TITLE
[low] fix: [wifi_geolocation_kml] gx: prefix is used but never declared, so every KML is not namespace-well-formed

### DIFF
--- a/src/sysdiagnose/analysers/wifi_geolocation_kml.py
+++ b/src/sysdiagnose/analysers/wifi_geolocation_kml.py
@@ -25,7 +25,15 @@ class WifiGeolocationKmlAnalyser(BaseAnalyserInterface):
     @staticmethod
     def generate_kml_from_known_networks_json(json_data: dict) -> str:
         """Generates KML XML string from known networks JSON data."""
-        kml = ET.Element("kml", xmlns="http://www.opengis.net/kml/2.2")
+        # the gx: prefix is used below (gx:Tour, gx:Playlist, gx:FlyTo, ...), so its namespace
+        # has to be declared on the root element or the document is not namespace-well-formed
+        kml = ET.Element(
+            "kml",
+            {
+                "xmlns": "http://www.opengis.net/kml/2.2",
+                "xmlns:gx": "http://www.google.com/kml/ext/2.2",
+            },
+        )
         document = ET.SubElement(kml, "Document")
 
         # Add tour elements

--- a/tests/test_analysers_wifi_geolocation_kml.py
+++ b/tests/test_analysers_wifi_geolocation_kml.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import xml.etree.ElementTree as ET
 
 from sysdiagnose.analysers.wifi_geolocation_kml import WifiGeolocationKmlAnalyser
 from tests import SysdiagnoseTestCase
@@ -19,6 +20,23 @@ class TestAnalysersWifiGeolocationKml(SysdiagnoseTestCase):
                 self.assertTrue(os.path.getsize(a.output_file) > 0)
                 self.assert_result_summary_consistent(a, a.get_result())
                 # FIXME check for something else within the file...
+
+    def test_generated_kml_is_namespace_well_formed(self):
+        """The gx: prefix must be declared, otherwise no conforming XML parser can read the file."""
+        kml = WifiGeolocationKmlAnalyser.generate_kml_from_known_networks_json(
+            {
+                "net1": {
+                    "SSID": "test-ssid",
+                    "AddedAt": "2023-05-24T13:29:15Z",
+                    "Latitude": 1.0,
+                    "Longitude": 2.0,
+                }
+            }
+        )
+        # on main this raises ParseError: unbound prefix
+        root = ET.fromstring(kml)
+        self.assertEqual("{http://www.opengis.net/kml/2.2}kml", root.tag)
+        self.assertIn("http://www.google.com/kml/ext/2.2", kml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## BLUF

- **Priority: low** in scope, but the output is **completely unusable**, not merely imperfect: every KML this analyser has ever produced fails to parse.
- **The `gx:` prefix is used but never declared.** The root element declares only the default KML namespace, while five elements below use `gx:` — `gx:Tour`, `gx:Playlist`, `gx:FlyTo`, `gx:duration`, `gx:flyToMode`.
- **This is not a validation nicety — it is a well-formedness error.** An undeclared namespace prefix makes the document malformed, so a conforming parser refuses it outright. `xml.etree.ElementTree.fromstring()` on the current output raises `ParseError: unbound prefix: line 2, column 54`.
- **`ElementTree` will not catch this on the writing side.** It treats `"gx:Tour"` as an opaque tag name and serialises it verbatim, so generation succeeds silently and the failure only appears when something tries to read the file — Google Earth, a KML library, or an analyst's own tooling.
- **Fix:** declare `xmlns:gx="http://www.google.com/kml/ext/2.2"` — the standard Google KML extension namespace that these elements belong to — on the root element.
- **Scope:** one element construction in `wifi_geolocation_kml.py`, plus a regression test.

## Before

```xml
<kml xmlns="http://www.opengis.net/kml/2.2"><Document><gx:Tour>...
```

```
xml.etree.ElementTree.ParseError: unbound prefix: line 2, column 54
```

## After

```xml
<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2"><Document><gx:Tour>...
```

Parses cleanly; root tag resolves to `{http://www.opengis.net/kml/2.2}kml`.

## Test

`test_generated_kml_is_namespace_well_formed` generates a KML from a one-network input and runs `ET.fromstring()` over it, asserting the root tag resolves in the KML namespace and the `gx` namespace URI is present.

Verified to fail on `main` with `ParseError: unbound prefix` and pass with this change. The existing `test_analyse_wifi_geolocation_kml` only asserts the output file is non-empty, so it is unaffected.
